### PR TITLE
create a link from nvidia-kubevirt-gpu-device-plugin 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ LABEL summary="NVIDIA Sandbox Device Plugin"
 LABEL description="See summary"
 
 COPY --from=builder /go/src/sandbox-device-plugin/nvidia-sandbox-device-plugin /usr/bin/
+COPY --link --from=builder /go/src/sandbox-device-plugin/nvidia-sandbox-device-plugin /usr/bin/nvidia-kubevirt-gpu-device-plugin
 COPY --from=builder /go/src/sandbox-device-plugin/utils/pci.ids /usr/pci.ids
 
 USER 0:0


### PR DESCRIPTION
to nvidia-sandbox-device-plugin for backward compatibility

@jojimt PTAL