### PR TITLE
remove arm64 scan, update project name, update base distroless image

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -124,14 +124,15 @@ scan-distroless-amd64:
     - .scan-distroless
     - .platform-amd64
 
-scan-distroless-arm64:
-  extends:
-    - .scan-distroless
-    - .platform-arm64
-  # For now, run the scans sequentially to avoid any issues
-  # when pulling the same tag, but different arch, on the gitlab runner
-  needs:
-    - scan-distroless-amd64
+# Do not need to run arm64 now, because CoCo does not have arm support until Vera/Rubin
+#scan-distroless-arm64:
+#  extends:
+#    - .scan-distroless
+#    - .platform-arm64
+#  # For now, run the scans sequentially to avoid any issues
+#  # when pulling the same tag, but different arch, on the gitlab runner
+#  needs:
+#    - scan-distroless-amd64
 
 .ngc-publish-variables:
   before_script:
@@ -152,7 +153,7 @@ scan-distroless-arm64:
     name: "${CNT_NGC_PUBLISH_IMAGE}"
     pull_policy: always
   variables:
-    PROJECT_NAME: "nvidia-sandbox-device-plugin"
+    PROJECT_NAME: "sandbox-device-plugin"
     REPO_URL: "https://github.com/NVIDIA/sandbox-device-plugin.git"
   script:
     - |
@@ -193,8 +194,8 @@ update-nspect:
   variables:
     GITLAB_ACCESS_TOKEN: "${CNT_GITLAB_TOKEN}"
   script:
-    - cnt-ngc-publish render --project-name "nvidia-sandbox-device-plugin" --versions-file "build-info-${CI_PIPELINE_ID}.txt" --output nvidia-sandbox-device-plugin.yaml
-    - cnt-ngc-publish merge-request --files "nvidia-sandbox-device-plugin.yaml"
+    - cnt-ngc-publish render --project-name "sandbox-device-plugin" --versions-file "build-info-${CI_PIPELINE_ID}.txt" --output sandbox-device-plugin.yaml
+    - cnt-ngc-publish merge-request --files "sandbox-device-plugin.yaml"
 
 # Raise an MR to publish the image to NGC
 ngc-image-publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY . .
 
 RUN make build
 
-FROM nvcr.io/nvidia/distroless/go:v3.1.11
+FROM nvcr.io/nvidia/distroless/go:v3.2.1
 
 ARG VERSION
 

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM nvcr.io/nvidia/cuda:12.9.1-base-ubi9 as builder
+FROM nvcr.io/nvidia/cuda:13.0.2-base-ubi9 as builder
 
 RUN yum install -y wget make gcc
 
@@ -53,7 +53,7 @@ COPY . .
 
 RUN make build
 
-FROM nvcr.io/nvidia/distroless/go:v3.1.11
+FROM nvcr.io/nvidia/distroless/go:v3.2.1
 
 ARG VERSION
 


### PR DESCRIPTION
@jojimt PTAL

- Docker base image upgrade for CVE fixes.
- Downstream CI update project name to match PLC
- Downstream CI shouldn't wait arm64 image