### PR TITLE
fix: entrypoint should be complete path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ COPY --link --from=builder /go/src/sandbox-device-plugin/nvidia-sandbox-device-p
 COPY --from=builder /go/src/sandbox-device-plugin/utils/pci.ids /usr/pci.ids
 COPY --from=gfd /usr/bin/gpu-feature-discovery /usr/bin/gpu-feature-discovery
 
-CMD ["nvidia-sandbox-device-plugin"]
+CMD ["/usr/bin/nvidia-sandbox-device-plugin"]

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -76,4 +76,4 @@ COPY --link --from=builder /go/src/sandbox-device-plugin/nvidia-sandbox-device-p
 COPY --from=builder /go/src/sandbox-device-plugin/utils/pci.ids /usr/pci.ids
 COPY --from=gfd /usr/bin/gpu-feature-discovery /usr/bin/gpu-feature-discovery
 
-CMD ["nvidia-sandbox-device-plugin"]
+CMD ["/usr/bin/nvidia-sandbox-device-plugin"]


### PR DESCRIPTION
/usr/bin/nvidia-sandbox-device-plugin because distroless base does not have the correct PATH variable set