### PR TITLE
upgrade gfd to 0.19.0 for critical CVE fix in golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM nvcr.io/nvidia/k8s-device-plugin:v0.19.0 as gfd
+ARG GFD_IMAGE=nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+ARG BUILDER_IMAGE=nvcr.io/nvidia/cuda:13.2.0-base-ubi9
+ARG DISTROLESS_BASE_IMAGE=nvcr.io/nvidia/distroless/go:v4.0.2-dev
 
-FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi9 as builder
+FROM ${GFD_IMAGE} as gfd
+
+FROM ${BUILDER_IMAGE} as builder
 
 RUN yum install -y wget make gcc
 
@@ -55,7 +59,7 @@ COPY . .
 
 RUN make build
 
-FROM nvcr.io/nvidia/distroless/go:v4.0.2-dev
+FROM ${DISTROLESS_BASE_IMAGE}
 
 USER 0:0
 SHELL ["/busybox/sh", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM nvcr.io/nvidia/k8s-device-plugin:v0.18.2 as gfd
+FROM nvcr.io/nvidia/k8s-device-plugin:v0.19.0 as gfd
 
 FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi9 as builder
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+##### Global variables #####
+include $(CURDIR)/versions.mk
+
 DOCKER_REPO ?= "nvcr.io/nvidia/sandbox-device-plugin"
 DOCKER_TAG ?= v1.4.1
 
@@ -38,7 +41,16 @@ coverage:
 clean:
 	rm -f nvidia-sandbox-device-plugin && rm -rf coverage.out
 build-local-image:
-	docker build . -t $(DOCKER_REPO):$(DOCKER_TAG) 
+	docker build \
+		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
+		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg DISTROLESS_BASE_IMAGE="$(DISTROLESS_BASE_IMAGE)" \
+		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
+		--build-arg GFD_IMAGE="$(GFD_IMAGE)" \
+		. -t $(DOCKER_REPO):$(DOCKER_TAG)
 push-image: build-local-image
 	 docker push $(DOCKER_REPO):$(DOCKER_TAG)
 update-pcidb:

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ coverage:
 	go tool cover -html=coverage.out
 clean:
 	rm -f nvidia-sandbox-device-plugin && rm -rf coverage.out
-build-image:
+build-local-image:
 	docker build . -t $(DOCKER_REPO):$(DOCKER_TAG) 
-push-image: build-image
+push-image: build-local-image
 	 docker push $(DOCKER_REPO):$(DOCKER_TAG)
 update-pcidb:
 	wget $(PCI_IDS_URL) -O $(CURDIR)/utils/pci.ids

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM nvcr.io/nvidia/k8s-device-plugin:v0.18.2 as gfd
+FROM nvcr.io/nvidia/k8s-device-plugin:v0.19.0 as gfd
 
 FROM nvcr.io/nvidia/cuda:13.1.1-base-ubi9 as builder
 

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -26,7 +26,7 @@
 
 FROM nvcr.io/nvidia/k8s-device-plugin:v0.19.0 as gfd
 
-FROM nvcr.io/nvidia/cuda:13.1.1-base-ubi9 as builder
+FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi9 as builder
 
 RUN yum install -y wget make gcc
 

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -24,9 +24,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM nvcr.io/nvidia/k8s-device-plugin:v0.19.0 as gfd
+ARG GFD_IMAGE=nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+ARG BUILDER_IMAGE=nvcr.io/nvidia/cuda:13.2.0-base-ubi9
+ARG DISTROLESS_BASE_IMAGE=nvcr.io/nvidia/distroless/go:v4.0.2-dev
 
-FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi9 as builder
+FROM ${GFD_IMAGE} as gfd
+
+FROM ${BUILDER_IMAGE} as builder
 
 RUN yum install -y wget make gcc
 
@@ -58,7 +62,7 @@ COPY . .
 
 RUN make build
 
-FROM nvcr.io/nvidia/distroless/go:v4.0.2-dev
+FROM ${DISTROLESS_BASE_IMAGE}
 
 USER 0:0
 SHELL ["/busybox/sh", "-c"]

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -64,6 +64,9 @@ $(BUILD_TARGETS): build-%:
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg DISTROLESS_BASE_IMAGE="$(DISTROLESS_BASE_IMAGE)" \
+		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
+		--build-arg GFD_IMAGE="$(GFD_IMAGE)" \
 		--file $(DOCKERFILE) \
 		$(CURDIR)
 ifeq ($(PUSH_ON_BUILD),true)

--- a/versions.mk
+++ b/versions.mk
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 VERSION ?= v0.9.0
+DISTROLESS_BASE_IMAGE ?= nvcr.io/nvidia/distroless/go:v4.0.2-dev
+BUILDER_IMAGE ?= nvcr.io/nvidia/cuda:13.2.0-base-ubi9
+GFD_IMAGE ?= nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+
 MODULE := github.com/NVIDIA/sandbox-device-plugin
 
 vVERSION := v$(VERSION:v%=%)
-
 GOLANG_VERSION := $(shell ./scripts/golang-version.sh)
-
-BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
-BUILDIMAGE ?=  $(LIB_NAME):$(BUILDIMAGE_TAG)
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")


### PR DESCRIPTION
and upgrade the builder image version