### PR TITLE
Add support for VFIO enable_unsafe_noiommu_mode

### DIFF
--- a/pkg/device_plugin/cdi.go
+++ b/pkg/device_plugin/cdi.go
@@ -141,9 +141,9 @@ func GenerateCDISpec() error {
 func generateCDISpecForClass(class string, scopedIommuKeys []string) error {
 	var deviceSpecs []specs.Device
 
-	iommufdSupported, err := supportsIOMMUFD()
+	iommufdSupported, noIOMMU, err := vfioBackendSupport()
 	if err != nil {
-		return fmt.Errorf("failed to check IOMMUFD support: %w", err)
+		return fmt.Errorf("could not determine vfio backend support: %w", err)
 	}
 
 	// Sort iommu keys to ensure deterministic device ordering in the CDI spec.
@@ -170,12 +170,16 @@ func generateCDISpecForClass(class string, scopedIommuKeys []string) error {
 					Path: filepath.Join(vfioDevicePath, "devices", dev.IommuFD),
 				})
 			} else {
+				groupName := iommuKey
+				if noIOMMU {
+					groupName = noiommuGroupPrefix + iommuKey
+				}
 				deviceNodes = append(deviceNodes,
 					&specs.DeviceNode{
 						Path: filepath.Join(vfioDevicePath, "vfio"),
 					},
 					&specs.DeviceNode{
-						Path: filepath.Join(vfioDevicePath, iommuKey),
+						Path: filepath.Join(vfioDevicePath, groupName),
 					},
 				)
 			}

--- a/pkg/device_plugin/cdi_test.go
+++ b/pkg/device_plugin/cdi_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package device_plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateCDISpecForClass_NoIOMMU(t *testing.T) {
+	tests := []struct {
+		name            string
+		noiommuParamVal string // empty string means file is absent
+		wantPaths       []string
+		unwantedPaths   []string
+	}{
+		{
+			name:            "plain group paths when noiommu mode is disabled",
+			noiommuParamVal: "N\n",
+			wantPaths:       []string{"/dev/vfio/vfio", "/dev/vfio/1", "/dev/vfio/2"},
+			unwantedPaths:   []string{"noiommu"},
+		},
+		{
+			name:            "plain group paths when noiommu param is absent",
+			noiommuParamVal: "",
+			wantPaths:       []string{"/dev/vfio/vfio", "/dev/vfio/1", "/dev/vfio/2"},
+			unwantedPaths:   []string{"noiommu"},
+		},
+		{
+			name:            "noiommu- prefixed paths when noiommu mode is enabled",
+			noiommuParamVal: "Y\n",
+			wantPaths:       []string{"/dev/vfio/vfio", "/dev/vfio/noiommu-1", "/dev/vfio/noiommu-2"},
+			unwantedPaths:   []string{"/dev/vfio/1", "/dev/vfio/2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			rootPath = workDir
+			setCdiRoot(filepath.Join(workDir, "cdi"))
+
+			iommuMap = map[string][]NvidiaPCIDevice{
+				"1": {{Address: "0000:01:00.0", DeviceID: 0x1b80, DeviceName: "GeForce GTX 1080", IommuGroup: 1}},
+				"2": {{Address: "0000:02:00.0", DeviceID: 0x1b80, DeviceName: "GeForce GTX 1080", IommuGroup: 2}},
+			}
+
+			if tt.noiommuParamVal != "" {
+				dir := filepath.Join(workDir, "sys", "module", "vfio", "parameters")
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("failed to create sysfs param dir: %v", err)
+				}
+				if err := os.WriteFile(
+					filepath.Join(dir, "enable_unsafe_noiommu_mode"),
+					[]byte(tt.noiommuParamVal), 0444,
+				); err != nil {
+					t.Fatalf("failed to write noiommu param: %v", err)
+				}
+			}
+
+			if err := generateCDISpecForClass("pgpu", []string{"1", "2"}); err != nil {
+				t.Fatalf("generateCDISpecForClass returned error: %v", err)
+			}
+
+			files, err := filepath.Glob(filepath.Join(workDir, "cdi", "*.yaml"))
+			if err != nil {
+				t.Fatalf("failed to glob CDI spec files: %v", err)
+			}
+			if len(files) != 1 {
+				t.Fatalf("expected 1 CDI spec file, got %d", len(files))
+			}
+			data, err := os.ReadFile(files[0])
+			if err != nil {
+				t.Fatalf("failed to read CDI spec file: %v", err)
+			}
+			content := string(data)
+
+			for _, path := range tt.wantPaths {
+				if !strings.Contains(content, path) {
+					t.Errorf("CDI spec missing expected path %q\nspec content:\n%s", path, content)
+				}
+			}
+			for _, path := range tt.unwantedPaths {
+				if strings.Contains(content, path) {
+					t.Errorf("CDI spec contains unexpected path %q\nspec content:\n%s", path, content)
+				}
+			}
+		})
+	}
+}

--- a/pkg/device_plugin/constants.go
+++ b/pkg/device_plugin/constants.go
@@ -33,12 +33,14 @@ import (
 )
 
 const (
-	DeviceNamespace   = "nvidia.com"
-	connectionTimeout = 5 * time.Second
-	vfioDevicePath    = "/dev/vfio"
-	iommuDevicePath   = "/dev/iommu"
-	gpuPrefix         = "PCI_RESOURCE_NVIDIA_COM"
-	cdiVendor         = "nvidia.com"
+	DeviceNamespace        = "nvidia.com"
+	connectionTimeout      = 5 * time.Second
+	vfioDevicePath         = "/dev/vfio"
+	iommuDevicePath        = "/dev/iommu"
+	gpuPrefix              = "PCI_RESOURCE_NVIDIA_COM"
+	cdiVendor              = "nvidia.com"
+	vfioNoIOMMUParamPath   = "/sys/module/vfio/parameters/enable_unsafe_noiommu_mode"
+	noiommuGroupPrefix     = "noiommu-"
 )
 
 var (

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -81,12 +81,19 @@ func InitiateDevicePlugin() {
 func createDevicePlugins() {
 	var devicePlugins []*GenericDevicePlugin
 	var devs []*pluginapi.Device
-	iommufdSupported, err := supportsIOMMUFD()
+
+	iommufdSupported, noIOMMU, err := vfioBackendSupport()
 	if err != nil {
-		log.Printf("Could not find if IOMMU FD is supported: %v", err)
+		log.Printf("Could not determine vfio backend support: %v", err)
 		return
 	}
+
 	log.Printf("iommufd supported: %v", iommufdSupported)
+	log.Printf("enable_unsafe_noiommu_mode: %v", noIOMMU)
+	if noIOMMU {
+		log.Printf("WARNING: VFIO enable_unsafe_noiommu_mode is enabled. This is not recommended as devices may be able to DMA across VM boundaries.")
+	}
+
 	log.Printf("Device map: %v", deviceMap)
 
 	// Iterate over deviceMap to create device plugin for each type of device on the host
@@ -120,7 +127,9 @@ func createDevicePlugins() {
 
 		log.Printf("Registering device plugin %q with %d device(s)", deviceName, len(devs))
 		devicePath := "/dev/vfio/"
-		if iommufdSupported {
+		// IOMMUFD does not currently support enable_unsafe_noiommu_mode, so if that mode is enabled we have to use the
+		// legacy IOMMU group paths even if IOMMUFD is supported.
+		if iommufdSupported && !noIOMMU {
 			devicePath = "/dev/vfio/devices/"
 		}
 		dp := NewGenericDevicePlugin(deviceName, devicePath, devs)

--- a/pkg/device_plugin/generic_device_plugin.go
+++ b/pkg/device_plugin/generic_device_plugin.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -240,6 +241,10 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 	if err != nil {
 		return nil, fmt.Errorf("could not determine iommufd support: %w", err)
 	}
+	noIOMMU, err := supportsNoIOMMU()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine noiommu mode: %w", err)
+	}
 	for _, req := range reqs.ContainerRequests {
 		deviceSpecs := make([]*pluginapi.DeviceSpec, 0)
 		for _, iommuID := range req.DevicesIDs {
@@ -250,7 +255,7 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 				return nil, fmt.Errorf("invalid allocation request: unknown iommu id: %s", iommuID)
 			}
 
-			if iommufdSupported {
+			if iommufdSupported && !noIOMMU {
 				for _, dev := range nvDevs {
 					log.Printf("iommufd: allocating device %s (iommufd: %s)", dev.Address, dev.IommuFD)
 					if dev.IommuFD == "" {
@@ -263,8 +268,12 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 					})
 				}
 			} else {
+				groupName := iommuID
+				if noIOMMU {
+					groupName = noiommuGroupPrefix + iommuID
+				}
 				for _, dev := range nvDevs {
-					log.Printf("vfio: allocating device %s (IOMMU group: %d)", dev.Address, dev.IommuGroup)
+					log.Printf("vfio: allocating device %s (IOMMU group: %d, noiommu: %v)", dev.Address, dev.IommuGroup, noIOMMU)
 				}
 				deviceSpecs = append(deviceSpecs, &pluginapi.DeviceSpec{
 					HostPath:      filepath.Join(vfioDevicePath, "vfio"),
@@ -272,8 +281,8 @@ func (dpi *GenericDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Al
 					Permissions:   "mrw",
 				})
 				deviceSpecs = append(deviceSpecs, &pluginapi.DeviceSpec{
-					HostPath:      filepath.Join(vfioDevicePath, iommuID),
-					ContainerPath: filepath.Join(vfioDevicePath, iommuID),
+					HostPath:      filepath.Join(vfioDevicePath, groupName),
+					ContainerPath: filepath.Join(vfioDevicePath, groupName),
 					Permissions:   "mrw",
 				})
 			}
@@ -328,9 +337,9 @@ func (dpi *GenericDevicePlugin) healthCheck() error {
 	var path = dpi.devicePath
 	var health = ""
 
-	iommufdSupported, err := supportsIOMMUFD()
+	iommufdSupported, noIOMMU, err := vfioBackendSupport()
 	if err != nil {
-		return fmt.Errorf("could not determine iommufd support: %w", err)
+		return fmt.Errorf("could not determine vfio backend support: %w", err)
 	}
 
 	watcher, err := fsnotify.NewWatcher()
@@ -358,6 +367,8 @@ func (dpi *GenericDevicePlugin) healthCheck() error {
 		devID := dev.ID
 		if iommufdSupported {
 			devID = fmt.Sprintf("vfio%s", dev.ID)
+		} else if noIOMMU {
+			devID = noiommuGroupPrefix + dev.ID
 		}
 		devicePath := filepath.Join(path, devID)
 		err = watcher.Add(devicePath)
@@ -409,4 +420,37 @@ func supportsIOMMUFD() (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// vfioBackendSupport checks for support of different vfio backend modes (IOMMUFD, noIOMMU) and returns the results as booleans.
+func vfioBackendSupport() (iommufd, noIOMMU bool, err error) {
+	hasIOMMUFD, err := supportsIOMMUFD()
+	if err != nil {
+		return false, false, fmt.Errorf("could not determine IOMMUFD support: %w", err)
+	}
+
+	hasNoIOMMU, err := supportsNoIOMMU()
+	if err != nil {
+		return false, false, fmt.Errorf("could not determine noIOMMU mode support: %w", err)
+	}
+
+	// When enable_unsafe_noiommu_mode is enabled, only the legacy VFIO interface is available.
+	// IOMMUFD does not yet support this mode, so even if the kernel provides the cdev, we have to use the legacy VFIO interface.
+	iommufd = hasIOMMUFD && !hasNoIOMMU
+	noIOMMU = hasNoIOMMU
+	return iommufd, noIOMMU, nil
+}
+
+// supportsNoIOMMU returns true when the vfio module is running with
+// enable_unsafe_noiommu_mode=Y.  In that mode the group device files are
+// named /dev/vfio/noiommu-<group> instead of /dev/vfio/<group>.
+func supportsNoIOMMU() (bool, error) {
+	content, err := os.ReadFile(filepath.Join(rootPath, vfioNoIOMMUParamPath))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(content)) == "Y", nil
 }

--- a/pkg/device_plugin/generic_device_plugin_test.go
+++ b/pkg/device_plugin/generic_device_plugin_test.go
@@ -85,6 +85,74 @@ func getFakeIommuMap() map[string][]NvidiaPCIDevice {
 	return tempMap
 }
 
+var _ = Describe("vfioBackendSupport", func() {
+	var workDir string
+
+	BeforeEach(func() {
+		var err error
+		workDir, err = os.MkdirTemp("", "vfio-backend-test")
+		Expect(err).ToNot(HaveOccurred())
+		rootPath = workDir
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(workDir)
+	})
+
+	writeNoIOMMUParam := func(value string) {
+		dir := filepath.Join(workDir, "sys", "module", "vfio", "parameters")
+		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, "enable_unsafe_noiommu_mode"), []byte(value), 0444)).To(Succeed())
+	}
+
+	createIOMMUFD := func() {
+		Expect(os.MkdirAll(filepath.Join(workDir, "dev"), 0755)).To(Succeed())
+		f, err := os.OpenFile(filepath.Join(workDir, "dev", "iommu"), os.O_RDONLY|os.O_CREATE, 0666)
+		Expect(err).ToNot(HaveOccurred())
+		f.Close()
+	}
+
+	It("returns false/false when neither iommufd nor noiommu is present", func() {
+		iommufd, noIOMMU, err := vfioBackendSupport()
+		Expect(err).To(BeNil())
+		Expect(iommufd).To(BeFalse())
+		Expect(noIOMMU).To(BeFalse())
+	})
+
+	It("returns iommufd=true/noIOMMU=false when only /dev/iommu is present", func() {
+		createIOMMUFD()
+		iommufd, noIOMMU, err := vfioBackendSupport()
+		Expect(err).To(BeNil())
+		Expect(iommufd).To(BeTrue())
+		Expect(noIOMMU).To(BeFalse())
+	})
+
+	It("returns iommufd=false/noIOMMU=true when only noiommu mode is enabled", func() {
+		writeNoIOMMUParam("Y\n")
+		iommufd, noIOMMU, err := vfioBackendSupport()
+		Expect(err).To(BeNil())
+		Expect(iommufd).To(BeFalse())
+		Expect(noIOMMU).To(BeTrue())
+	})
+
+	It("suppresses iommufd when both /dev/iommu and noiommu mode are present", func() {
+		createIOMMUFD()
+		writeNoIOMMUParam("Y\n")
+		iommufd, noIOMMU, err := vfioBackendSupport()
+		Expect(err).To(BeNil())
+		Expect(iommufd).To(BeFalse(), "iommufd should be suppressed in noiommu mode")
+		Expect(noIOMMU).To(BeTrue())
+	})
+
+	It("returns iommufd=false/noIOMMU=false when noiommu param is N", func() {
+		writeNoIOMMUParam("N\n")
+		iommufd, noIOMMU, err := vfioBackendSupport()
+		Expect(err).To(BeNil())
+		Expect(iommufd).To(BeFalse())
+		Expect(noIOMMU).To(BeFalse())
+	})
+})
+
 var _ = Describe("Generic Device", func() {
 	var workDir string
 	var err error
@@ -184,6 +252,29 @@ var _ = Describe("Generic Device", func() {
 		responses, err := dpi.Allocate(ctx, &requests)
 		Expect(err).ToNot(BeNil())
 		Expect(responses).To(BeNil())
+	})
+
+	It("Should allocate a device without error in noiommu mode", func() {
+		Expect(os.MkdirAll(filepath.Join(workDir, "sys", "module", "vfio", "parameters"), 0744)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(workDir, "sys", "module", "vfio", "parameters", "enable_unsafe_noiommu_mode"),
+			[]byte("Y\n"), 0444,
+		)).To(Succeed())
+
+		devs := []string{iommuGroup1}
+		containerRequests := pluginapi.ContainerAllocateRequest{DevicesIDs: devs}
+		requests := pluginapi.AllocateRequest{}
+		requests.ContainerRequests = append(requests.ContainerRequests, &containerRequests)
+		ctx := context.Background()
+		responses, err := dpi.Allocate(ctx, &requests)
+		Expect(err).To(BeNil())
+		Expect(responses.GetContainerResponses()[0].Envs).To(BeNil())
+		Expect(responses.GetContainerResponses()[0].Devices[0].HostPath).To(Equal("/dev/vfio/vfio"))
+		Expect(responses.GetContainerResponses()[0].Devices[0].ContainerPath).To(Equal("/dev/vfio/vfio"))
+		Expect(responses.GetContainerResponses()[0].Devices[0].Permissions).To(Equal("mrw"))
+		Expect(responses.GetContainerResponses()[0].Devices[1].HostPath).To(Equal("/dev/vfio/noiommu-1"))
+		Expect(responses.GetContainerResponses()[0].Devices[1].ContainerPath).To(Equal("/dev/vfio/noiommu-1"))
+		Expect(responses.GetContainerResponses()[0].Devices[1].Permissions).To(Equal("mrw"))
 	})
 
 	It("Should fail allocation for unknown iommu id", func() {


### PR DESCRIPTION
When the vfio kernel module runs with enable_unsafe_noiommu_mode=Y,
group device files are named /dev/vfio/noiommu-<group> instead of
/dev/vfio/<group>.  Detect this mode by reading
/sys/module/vfio/parameters/enable_unsafe_noiommu_mode and apply the
"noiommu-" prefix when constructing device paths in Allocate(),
generateCDISpecForClass(), and healthCheck().  The IOMMU group number
stored in iommuMap/deviceMap is unchanged; the prefix is only applied
at the filesystem path level.  IOMMUFD mode is unaffected.

Note that enable_unsafe_noiommu_mode can only be used with the legacy VFIO cdevs.
IOMMUFD does not yet support this.

The resulting CDI spec file looks like this:

```
---
cdiVersion: 0.5.0
kind: nvidia.com/pgpu
devices:
    - name: "0"
      containerEdits:
        deviceNodes:
            - path: /dev/vfio/vfio
            - path: /dev/vfio/noiommu-0
```

This was tested on an NVIDIA L40 node with the following parameters:

```
$  cat /sys/module/vfio/parameters/enable_unsafe_noiommu_mode
Y
$ file /dev/iommu
/dev/iommu: character special (10/114)
```

And you can see the noiommu cdevs:

```
$ ls /dev/vfio
noiommu-0  noiommu-1  noiommu-2  noiommu-3  noiommu-4  noiommu-5  noiommu-6  noiommu-7  vfio
```

Example logs from running the device plugin directly:

```
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.0 open /sys/bus/pci/devices/0000:17:00.0/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.1 open /sys/bus/pci/devices/0000:17:00.1/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.2 open /sys/bus/pci/devices/0000:17:00.2/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.3 open /sys/bus/pci/devices/0000:17:00.3/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.4 open /sys/bus/pci/devices/0000:17:00.4/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.5 open /sys/bus/pci/devices/0000:17:00.5/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.6 open /sys/bus/pci/devices/0000:17:00.6/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:00.7 open /sys/bus/pci/devices/0000:17:00.7/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 WARNING: unable to detect IOMMU FD for [0000:17:01.0 open /sys/bus/pci/devices/0000:17:01.0/vfio-dev: no such file or directory]: %!v(MISSING)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:20:00.0 (iommufd: vfio0)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:21:00.0 (iommufd: vfio1)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:45:00.0 (iommufd: vfio2)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:46:00.0 (iommufd: vfio3)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:ad:00.0 (iommufd: vfio4)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:ae:00.0 (iommufd: vfio5)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:c0:00.0 (iommufd: vfio6)
2026/03/18 20:50:35 Found GPU AD102GL [L40] [26b5] at 0000:c1:00.0 (iommufd: vfio7)
2026/03/18 20:50:35 Added CDI device 0: address=0000:20:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 1: address=0000:21:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 2: address=0000:45:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 3: address=0000:46:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 4: address=0000:ad:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 5: address=0000:ae:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 6: address=0000:c0:00.0, class=pgpu
2026/03/18 20:50:35 Added CDI device 7: address=0000:c1:00.0, class=pgpu
2026/03/18 20:50:35 Generated CDI spec: nvidia.com-pgpu with 8 devices
2026/03/18 20:50:35 iommufd supported: false
2026/03/18 20:50:35 enable_unsafe_noiommu_mode: true
2026/03/18 20:50:35 WARNING: VFIO enable_unsafe_noiommu_mode is enabled. This is not recommended as devices may be able to DMA across VM boundaries.
2026/03/18 20:50:35 Device map: map[26b5:[0 1 2 3 4 5 6 7]]
2026/03/18 20:50:35 Registering device plugin "pgpu" with 8 device(s)
2026/03/18 20:50:35 Devicename pgpu
2026/03/18 20:50:35 pgpu Device plugin server ready
2026/03/18 20:50:35 NODE_NAME environment variable is required for running GFD
2026/03/18 20:50:35 healthCheck(pgpu): invoked
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-0
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-1
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-2
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-3
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-4
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-5
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-6
2026/03/18 20:50:35  Adding Watcher to Path : /dev/vfio/noiommu-7
```

We can also see the `nvidia.com/pgpu` devices being advertised to the kubelet appropriately:

```
$ k describe node $NODE | grep nvidia.com/pgpu
  nvidia.com/pgpu:    8
```

CC @zvonkok 

References:
- https://lwn.net/Articles/660745/
- https://lwn.net/ml/all/20251201173012.18371-1-jacob.pan@linux.microsoft.com/