### PR TITLE
Ship static busybox shell in sandbox-device-plugin image

### DIFF
--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -26,7 +26,7 @@
 
 ARG GFD_IMAGE=nvcr.io/nvidia/k8s-device-plugin:v0.19.0
 ARG BUILDER_IMAGE=nvcr.io/nvidia/cuda:13.2.0-base-ubi9
-ARG DISTROLESS_BASE_IMAGE=nvcr.io/nvidia/distroless/go:v4.0.4-dev
+ARG DISTROLESS_BASE_IMAGE=nvcr.io/nvidia/distroless/go:v4.0.4
 
 FROM ${GFD_IMAGE} as gfd
 
@@ -62,11 +62,24 @@ COPY . .
 
 RUN make build
 
+# Build a static busybox layout: one binary plus applet symlinks (sh, rm,
+# ln, sleep, cat, ...) so PATH-resolved commands in init-container wrappers
+# and lifecycle hooks keep working on the non-*-dev* distroless base.
+FROM debian:trixie-slim AS shell
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends busybox-static \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /busybox \
+ && cp /bin/busybox /busybox/busybox \
+ && /busybox/busybox --install -s /busybox
+
 FROM ${DISTROLESS_BASE_IMAGE}
 
 USER 0:0
-SHELL ["/busybox/sh", "-c"]
-RUN ln -s /busybox/sh /bin/sh
+
+COPY --from=shell /busybox /busybox
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
 
 ARG VERSION
 


### PR DESCRIPTION
Flip the `DISTROLESS_BASE_IMAGE` default from `*-dev*` to non-`*-dev*` distroless and source a static busybox from `debian:trixie-slim`. The sandbox-device-plugin entrypoint continues to work via `/bin/sh` and busybox applet symlinks layered into the final image.

Part of NVIDIA/cloud-native-team#299.
Resolves #81.